### PR TITLE
ci: OIDC npm publish, typedoc warning gate, real AGENTS.md

### DIFF
--- a/.github/workflows/action-deploy-npm.yaml
+++ b/.github/workflows/action-deploy-npm.yaml
@@ -57,14 +57,26 @@ jobs:
         env:
           GITHUB_EVENT_RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
 
+      # OIDC trusted publishing + provenance require npm >= 11.5.1 (the LTS
+      # image ships 10.x). No NPM_TOKEN -- npm verifies the OIDC token GitHub
+      # issues against the trusted publisher registered on npmjs.com for this
+      # workflow file (action-deploy-npm.yaml, case-sensitive).
+      - name: Upgrade npm
+        run: |
+          npm install -g npm@latest
+          npm --version
+
+      # Idempotent: skip if that exact version is already on the registry
+      # (partial-publish retry).
       - name: Publish to npm
-        uses: JS-DevTools/npm-publish@v4
-        with:
-          provenance: true
-          access: public
-          ignore-scripts: true
-          token: ${{ secrets.NPM_TOKEN }}
-          tag: ${{ steps.set-npm-tag.outputs.NPM_TAG }}
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          NAME=$(node -p "require('./package.json').name")
+          if npm view "${NAME}@${VERSION}" version >/dev/null 2>&1; then
+            echo "${NAME}@${VERSION} already published -- skipping."
+          else
+            npm publish --provenance --access public --ignore-scripts --tag "${{ steps.set-npm-tag.outputs.NPM_TAG }}"
+          fi
 
   Document:
     needs: ['Publish']

--- a/.github/workflows/action-test.yaml
+++ b/.github/workflows/action-test.yaml
@@ -51,6 +51,12 @@ jobs:
         run: |
           npm run build
 
+      # Gate on the docs build too: typedoc.json sets treatWarningsAsErrors,
+      # so a dangling/undocumented reference fails the PR instead of slipping in.
+      - name: Build Docs (warnings fail the build)
+        run: |
+          npm run typedoc
+
       - name: Upload build artifact
         if: matrix.node-version == 'lts/*'
         uses: actions/upload-artifact@v7

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,36 +5,64 @@ hook-enforced rules). Keep this file current when the build, layout, or public A
 
 ## What this is
 
-An NPM package that can give you astronomy information about various cosmic and natural objects in our solar system.
+A pure-TypeScript astronomy library that computes information about solar-system objects and stars:
+planet/sun/moon positions, rise/set and twilight times, moon phases, and constellations. No runtime
+services or network calls — every result is computed from a supplied time and (where relevant) an
+observer location.
 
-<!-- Fill in: what the project does, what it ships (library, service, action, CLI), and the one or
-two things an agent must understand before changing it. -->
+Published to npm as `node-astronomy`. Ships dual ESM + CJS with type declarations (built to `lib/`).
 
-## Using node-astronomy
+## Using node-astronomy in an app
 
-<!-- If this project is consumed by others (a library/plugin/action), describe the contract a
-consumer must respect: the single entry point, the public surface, required options, and anything
-that must not be bypassed. Delete this section for a leaf application. -->
+If you are an agent consuming this package, the contract:
+
+- **Single entry point.** Import everything from `node-astronomy` (do not deep-import `lib/...`). The
+  surface includes the snapshot classes (`Sun`, `Moon`, `Planet` and its subclasses `Mercury`,
+  `Venus`, `Earth`, `Mars`, `Jupiter`, `Saturn`, `Uranus`, `Neptune`, `Pluto`), the time helpers
+  (`SunTimes`, `MoonTimes`, `MoonPhase`, `StarTimes`), `Celestial`/`Star`/`Constellation`,
+  `TimeOfInterest`, and functions like `findConstellationAt`, `getNamedStar`, `listNamedStars`,
+  `visibleConstellations`.
+- **Construct a snapshot with a time.** Pass `{ time }` where `time` is a `Date` (or a
+  `TimeOfInterest`). Times are UTC instants.
+
+```ts
+import { Mars, type PlanetName } from "node-astronomy";
+
+const mars = new Mars({ time: new Date("2026-04-30T22:00:00Z") });
+mars.planet;               // "mars"
+mars.symbol();             // "Mars"  (a word, not the astronomical glyph)
+mars.eclipticCoordinate(); // { longitude: number /* 0..360 */, latitude: number /* -90..90 */ }
+```
+
+- **CJS works too:** `const { Mars } = require("node-astronomy");`.
+- **Import types from this package**, not from internal paths: `import type { PlanetName } from "node-astronomy"`.
+- `symbol()` returns the planet **name in words** (e.g. `"Mars"`), not the Unicode astrological glyph
+  — the glyphs were dropped so the source stays ASCII-only.
 
 ## Layout
 
-<!-- The directories that matter and what lives in each. Keep it short; point at the entry points. -->
-
-- `src/` - <what>
-- `<tests dir>/` - <what>
+- `src/index.ts` - the public entry point; re-exports the surface below.
+- `src/astronomicalObject/` - the consumer-facing snapshot classes (`Planet` + subclasses, `Sun`,
+  `Moon`, `Celestial`, `Star`, `Constellation`) and their `*Times`/`*Phase` helpers.
+- `src/astrometry/` - the underlying math (VSOP87 earth/heliocentric, moon terms, planet
+  geo/heliocentric, sun anomaly/ecliptic, constellations, transit/hour-angle/circumpolar).
+- `src/time/` - `TimeOfInterest` and time conversions.
+- `src/util/` - angle and coordinate transforms.
+- `__tests__/` - the vitest suite (pinned reference times; pure computation, no external services).
 
 ## Build, test, lint
 
-<!-- The exact commands. Pull these from package.json scripts (npm), the Taskfile (Go/Task), or
-pyproject (Python) so they stay accurate. -->
-
-- Build: `<command>`
-- Test: `<command>` (note any service/fixture the integration tests require)
-- Lint: `<command>`
-- License headers / docs: `<command>`
+- Build: `npm run build` (tsdown -> ESM+CJS in `lib/`, with type declarations).
+- Test: `npm test` (vitest; no broker/service needed). Coverage: `npm run test:coverage`.
+- Lint: `npm run lint` (`eslint | snazzy`); `npm run lint:fix` to autofix.
+- Docs: `npm run typedoc` — `typedoc.json` sets `treatWarningsAsErrors`, so a dangling or
+  undocumented reference fails the build (and the PR, since `action-test` runs it).
+- License headers: `task license` verifies the MIT header (CI); `task license:fix` injects it.
 
 ## Conventions and gotchas
 
 - See `CLAUDE.md` for the branch/commit/PR rules; they are enforced by the git hooks in
   `.claude/hooks` (run `bash .claude/hooks/install.sh` once per clone).
-- <project-specific conventions, non-obvious constraints, and traps an agent should know>
+- No Unicode glyphs in source — astronomical/astrological symbols are stored as words (the emoji scan
+  blocks raw glyphs). Keep new doc comments to ASCII (`->`, `approx`) rather than `→`, `≈`.
+- Times are UTC; rise/set and twilight computations also need an observer location.

--- a/typedoc.json
+++ b/typedoc.json
@@ -3,6 +3,8 @@
   "entryPoints": ["src/index.ts"],
   "excludeExternals": true,
   "excludeInternal": true,
+  "treatWarningsAsErrors": true,
+  "intentionallyNotExported": ["ConstellationName", "rawData", "Interval"],
   "includeVersion": true,
   "githubPages": false,
   "plugin": ["@shipgirl/typedoc-plugin-versions"],


### PR DESCRIPTION
## What and why

Pre-release polish for node-astronomy, finishing the unify before publishing v0.2.0.

- **OIDC publish** — `action-deploy-npm.yaml` now publishes via npm OIDC trusted publishing (`npm publish --provenance`, no `NPM_TOKEN`), upgrades npm to the required version, skips an already-published version, and keeps the alpha/beta/rc dist-tag logic.
- **typedoc warning gate** — cleared the 3 "referenced but not included" warnings via `intentionallyNotExported`, set `treatWarningsAsErrors` in `typedoc.json`, and added a `npm run typedoc` step to `action-test` so doc warnings fail a PR.
- **AGENTS.md** — replaced the placeholder baseline with the real consumer contract (entry point, `new X({ time })`, `symbol()` returns words, import types from the package), layout, and commands.

## Closes

Closes #20
Closes #21
Closes #22

## Prerequisite before the next publish

Register the npm **trusted publisher** for `node-astronomy` on npmjs.com bound to `action-deploy-npm.yaml` (case-sensitive) — the OIDC publish replaces the `NPM_TOKEN` path, so without the trusted publisher the v0.2.0 publish will fail.

## Verification

- `action-deploy-npm.yaml` and `action-test.yaml` parse as valid YAML.
- `npm run typedoc` exits 0 (no warnings); `npm run lint` clean; build green.

## Closing summary

node-astronomy publishes with provenance over OIDC, doc warnings can't regress, and AGENTS.md is a real guide. Set up the npm trusted publisher before publishing v0.2.0.