### PR TITLE
ci: make the label checker tolerant of Dependabot's read-only token

### DIFF
--- a/.github/workflows/job-label-checker.yaml
+++ b/.github/workflows/job-label-checker.yaml
@@ -22,7 +22,12 @@ jobs:
     name: Autolabel
     runs-on: ubuntu-latest
     steps:
+      # Best-effort: Dependabot-triggered runs get a read-only GITHUB_TOKEN, so
+      # release-drafter cannot apply a label. Don't fail the job on that --
+      # Dependabot already sets a categorizing label (`dependencies`) from
+      # dependabot.yml, so the check below still passes.
       - name: Apply labels from PR title
+        continue-on-error: true
         uses: release-drafter/release-drafter@v6
         with:
           disable-releaser: true
@@ -32,6 +37,9 @@ jobs:
   categorizing-label:
     name: Categorizing label present
     needs: [autolabel]
+    # Run even if autolabel was skipped/failed (e.g. a Dependabot read-only
+    # token); the label may already be present from the PR title or dependabot.yml.
+    if: always()
     runs-on: ubuntu-latest
     steps:
       - uses: danielchabr/pr-labels-checker@v3.3


### PR DESCRIPTION
## What and why

Dependabot runs get a read-only `GITHUB_TOKEN`, so the autolabel step failed and `categorizing-label` was skipped, leaving Dependabot PRs (e.g. #25) showing a red `Autolabel`. `continue-on-error` on autolabel + `if: always()` on the check, so it reads the `dependencies` label Dependabot already sets via `dependabot.yml`. Human PRs unaffected.

## Closes

Closes #27

## Verification

- YAML valid. With the ruleset's review-off + required Build matrix, this clears the only remaining red on green Dependabot PRs so they auto-merge.