### PR TITLE
chore: drop ci entry with no heading from v0.2.2 changelog

### DIFF
--- a/.github/workflows/job-label-checker.yaml
+++ b/.github/workflows/job-label-checker.yaml
@@ -28,9 +28,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Map the conventional-commit prefix in the PR title to a categorizing
-      # label and apply it. Best-effort: Dependabot-triggered runs get a
-      # read-only GITHUB_TOKEN so the apply is skipped -- Dependabot already sets
-      # `dependencies` from dependabot.yml, so the check below still passes.
+      # label and apply it. Best-effort (continue-on-error): the
+      # categorizing-label job below is the authoritative check.
       - name: Apply label from PR title
         continue-on-error: true
         env:
@@ -60,8 +59,8 @@ jobs:
   categorizing-label:
     name: Categorizing label present
     needs: [autolabel]
-    # Run even if autolabel was skipped/failed (e.g. a Dependabot read-only
-    # token); the label may already be present from the PR title or dependabot.yml.
+    # Run even if autolabel was skipped/failed; the label may already be present
+    # from the PR title.
     if: always()
     runs-on: ubuntu-latest
     permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@
 
 ### What Changed 👀
 
-- ci: Release Manager commits as the owner, not github-actions[bot] @Bugs5382 (#30)
-
 #### 🧩 Dependency Updates
 
 - chore(deps): bump the github-actions group across 1 directory with 8 updates @[dependabot[bot]](https://github.com/apps/dependabot) (#25)


### PR DESCRIPTION
## What and why

PR #30 (`ci:`) merged without a `skip-changelog` label, so release-drafter listed it as an uncategorized entry under v0.2.2. It is now relabeled, and this removes it from CHANGELOG.md. The published v0.2.2 body will be corrected separately.

Closes #36

## Verification

- [x] v0.2.2 section now shows only the dependency update

## How this was verified

Reviewed the v0.2.2 section after the edit.